### PR TITLE
Fixup Z-Perl to work with the Classic Burning Crusade.

### DIFF
--- a/ZPerl/!Changelog.txt
+++ b/ZPerl/!Changelog.txt
@@ -1,3 +1,6 @@
+**6.1.7**
+* Update for Burning Crusade Classic compatability.
+
 **6.1.6**
 * Update Retail for 9.0.5.
 * Raid health bar tweaks.

--- a/ZPerl/Libs/LibClassicCasterino/LibClassicCasterino.lua
+++ b/ZPerl/Libs/LibClassicCasterino/LibClassicCasterino.lua
@@ -2,7 +2,7 @@
 LibClassicCasterino
 Author: d87
 --]================]
-if WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC then return end
+if WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC then return end
 
 local MAJOR, MINOR = "LibClassicCasterino", 35
 local lib = LibStub:NewLibrary(MAJOR, MINOR)

--- a/ZPerl/Libs/LibClassicDurations/LibClassicDurations.xml
+++ b/ZPerl/Libs/LibClassicDurations/LibClassicDurations.xml
@@ -5,3 +5,4 @@
 	<Script file="diminishingReturns.lua"/>
 	<Script file="npcAbilities.lua"/>
 </Ui>
+

--- a/ZPerl/Libs/LibClassicDurations/core.lua
+++ b/ZPerl/Libs/LibClassicDurations/core.lua
@@ -17,7 +17,7 @@ Usage example 1:
 	end
 
 --]================]
-if WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC then return end
+if WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC then return end
 
 local MAJOR, MINOR = "LibClassicDurations", 64
 local lib = LibStub:NewLibrary(MAJOR, MINOR)

--- a/ZPerl/ZPerl.lua
+++ b/ZPerl/ZPerl.lua
@@ -11,7 +11,7 @@ XPerl_RequestConfig(function(New)
 end, "$Revision: @project-revision@ $")
 XPerl_SetModuleRevision("$Revision: @project-revision@ $")
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 local LCD = IsClassic and LibStub and LibStub("LibClassicDurations", true)
 local UnitAuraDirect
 if LCD then

--- a/ZPerl/ZPerl.toc
+++ b/ZPerl/ZPerl.toc
@@ -1,7 +1,7 @@
-## Interface: 90005
+## Interface: 20501
 ## Version: 6.1.6
 ## Author: Resike
-## Title: Z-Perl UnitFrames
+## Title: Z-Perl UnitFramse
 ## Title-itIT: Z-Perl UnitFrames
 ## Title-ruRU: Z-Perl UnitFrames
 ## Title-deDE: Z-Perl UnitFrames
@@ -20,7 +20,7 @@
 
 Libs\LibStub\LibStub.lua
 Libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
-libs\LibClassicCasterino\LibClassicCasterino.lua
+Libs\LibClassicCasterino\LibClassicCasterino.lua
 Libs\LibClassicDurations\LibClassicDurations.xml
 Libs\LibHealComm-4.0\LibHealComm-4.0.xml
 Libs\MSA-DropDownMenu-1.0\MSA-DropDownMenu-1.0.lua

--- a/ZPerl/ZPerl.toc
+++ b/ZPerl/ZPerl.toc
@@ -1,7 +1,7 @@
 ## Interface: 20501
-## Version: 6.1.6
+## Version: 6.1.7
 ## Author: Resike
-## Title: Z-Perl UnitFramse
+## Title: Z-Perl UnitFrames
 ## Title-itIT: Z-Perl UnitFrames
 ## Title-ruRU: Z-Perl UnitFrames
 ## Title-deDE: Z-Perl UnitFrames

--- a/ZPerl/ZPerl_Highlight.lua
+++ b/ZPerl/ZPerl_Highlight.lua
@@ -15,7 +15,7 @@ if LCC then
     UnitChannelInfo = function(unit) return LCC:UnitChannelInfo(unit); end
 end
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local _G = _G
 

--- a/ZPerl/ZPerl_Init.lua
+++ b/ZPerl/ZPerl_Init.lua
@@ -8,7 +8,7 @@ XPerl_RequestConfig(function(new)
 	conf = new
 end, "$Revision: @file-revision@ $")
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local GetNumSubgroupMembers = GetNumSubgroupMembers
 local GetNumGroupMembers = GetNumGroupMembers

--- a/ZPerl/localization.lua
+++ b/ZPerl/localization.lua
@@ -2,7 +2,7 @@
 -- Author: Resike
 -- License: GNU GPL v3, 29 June 2007 (see LICENSE.txt)
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 XPerl_ProductName		= "|cFFD00000Z-Perl|r UnitFrames"
 XPerl_ShortProductName	= "|cFFD00000Z-Perl|r"

--- a/ZPerl_ArcaneBar/ZPerl_ArcaneBar.lua
+++ b/ZPerl_ArcaneBar/ZPerl_ArcaneBar.lua
@@ -23,7 +23,7 @@ if LCC then
     UnitChannelInfo = function(unit) return LCC:UnitChannelInfo(unit); end
 end
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 -- Registers frame to spellcast events.
 local barColours = {

--- a/ZPerl_ArcaneBar/ZPerl_ArcaneBar.toc
+++ b/ZPerl_ArcaneBar/ZPerl_ArcaneBar.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fArcane Bars|r
 ## Title-itIT: Z-Perl |cffeda55fBarre Arcane|r

--- a/ZPerl_CustomHighlight/ZPerl_CustomHighlight.lua
+++ b/ZPerl_CustomHighlight/ZPerl_CustomHighlight.lua
@@ -11,7 +11,7 @@ XPerl_RequestConfig(function(new)
 	conf = new.custom
 end, "$Revision: @file-revision@ $")
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local pairs = pairs
 local tinsert = tinsert

--- a/ZPerl_CustomHighlight/ZPerl_CustomHighlight.toc
+++ b/ZPerl_CustomHighlight/ZPerl_CustomHighlight.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fCustom Highlight|r
 ## Title-itIT: Z-Perl |cffeda55fEvidenziazioni Personalizzate|r

--- a/ZPerl_Options/ZPerl_FrameOptions.lua
+++ b/ZPerl_Options/ZPerl_FrameOptions.lua
@@ -4,7 +4,7 @@
 
 XPerl_SetModuleRevision("$Revision: @file-revision@ $")
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local localGroups = LOCALIZED_CLASS_NAMES_MALE
 local WoWclassCount = 0

--- a/ZPerl_Options/ZPerl_FrameOptions.xml
+++ b/ZPerl_Options/ZPerl_FrameOptions.xml
@@ -1271,7 +1271,7 @@
 					<OnLoad>
 						self:SetID(self:GetParent():GetID())
 						self.tooltipText = XPERL_CONF_RAID_CLASS_DOWN
-						if (self:GetID() == (WOW_PROJECT_ID == WOW_PROJECT_CLASSIC and 9 or 12)) then
+						if (self:GetID() == (WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC and 9 or 12)) then
 							self:Hide()
 						end
 					</OnLoad>
@@ -3840,7 +3840,7 @@
 						</Anchors>
 						<Scripts>
 							<OnLoad>
-								if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+								if WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC then
 									self:Hide()
 									return
 								end
@@ -12762,7 +12762,7 @@
 								</Anchors>
 								<Scripts>
 									<OnLoad>
-										if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+										if WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC then
 											self:Hide()
 											return
 										end
@@ -12789,7 +12789,7 @@
 								</Anchors>
 								<Scripts>
 									<OnLoad>
-										if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+										if WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC then
 											self:Hide()
 											return
 										end
@@ -12816,7 +12816,7 @@
 								</Anchors>
 								<Scripts>
 									<OnLoad>
-										if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+										if WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC then
 											self:Hide()
 											return
 										end
@@ -12947,7 +12947,7 @@
 								</Anchors>
 								<Scripts>
 									<OnLoad>
-										if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+										if WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC then
 											self:Hide()
 										end
 									</OnLoad>
@@ -12963,7 +12963,7 @@
 								</Anchors>
 								<Scripts>
 									<OnLoad>
-										if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+										if WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC then
 											self:Hide()
 										end
 									</OnLoad>
@@ -12980,7 +12980,7 @@
 								</Anchors>
 								<Scripts>
 									<OnLoad>
-										if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+										if WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC then
 											self:Hide()
 										end
 									</OnLoad>

--- a/ZPerl_Options/ZPerl_Options.toc
+++ b/ZPerl_Options/ZPerl_Options.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fOptions|r |cFF40FF40(LoadOnDemand)|r
 ## Title-itIT: Z-Perl |cffeda55fOpzioni|r |cFF40FF40(Caricabile su richiesta)|r

--- a/ZPerl_Options/localization.deDE.lua
+++ b/ZPerl_Options/localization.deDE.lua
@@ -2,7 +2,7 @@
 	Translated by Asixandur, Philipxander and Darkvalky
 ]]
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 if (GetLocale() == "deDE") then
 -- Tabs

--- a/ZPerl_Options/localization.itIT.lua
+++ b/ZPerl_Options/localization.itIT.lua
@@ -2,7 +2,7 @@
 	Translated by Asixandur, Philipxander and Darkvalky
 ]]
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 if (GetLocale() == "itIT") then
 -- Tabs

--- a/ZPerl_Options/localization.koKR.lua
+++ b/ZPerl_Options/localization.koKR.lua
@@ -2,7 +2,7 @@
 	Korean Localisation file By 地獄天使(kohalbae), Modified By DroArc, Fenlis
 ]]
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 if (GetLocale() == "koKR") then
 -- 탭 제목

--- a/ZPerl_Options/localization.lua
+++ b/ZPerl_Options/localization.lua
@@ -2,7 +2,7 @@
 	Localisation file
 ]]
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 -- Tabs
 XPERL_CONF_TITLE1						= "Global"

--- a/ZPerl_Options/localization.ruRU.lua
+++ b/ZPerl_Options/localization.ruRU.lua
@@ -2,7 +2,7 @@
 	Translated by StingerSoft
 ]]
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 if (GetLocale() == "ruRU") then
 -- Tabs

--- a/ZPerl_Options/localization.zhCN.lua
+++ b/ZPerl_Options/localization.zhCN.lua
@@ -2,7 +2,7 @@
 	Translation Updated by Xgale @20090222
 ]]
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 if (GetLocale() == "zhCN") then
 -- Tabs

--- a/ZPerl_Options/localization.zhTW.lua
+++ b/ZPerl_Options/localization.zhTW.lua
@@ -1,7 +1,7 @@
 --[[
 Localisation file
 ]]
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 if (GetLocale() == "zhTW") then
 -- Tabs

--- a/ZPerl_Party/ZPerl_Party.lua
+++ b/ZPerl_Party/ZPerl_Party.lua
@@ -17,7 +17,7 @@ end, "$Revision: @file-revision@ $")
 
 local percD = "%d"..PERCENT_SYMBOL
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local format = format
 

--- a/ZPerl_Party/ZPerl_Party.toc
+++ b/ZPerl_Party/ZPerl_Party.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fParty|r
 ## Title-itIT: Z-Perl |cffeda55fGruppo|r

--- a/ZPerl_PartyPet/ZPerl_PartyPet.lua
+++ b/ZPerl_PartyPet/ZPerl_PartyPet.lua
@@ -19,7 +19,7 @@ end, "$Revision: @file-revision@ $")
 
 local AllPetFrames = {}
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local UnitName = UnitName
 local UnitHealth = UnitHealth

--- a/ZPerl_PartyPet/ZPerl_PartyPet.toc
+++ b/ZPerl_PartyPet/ZPerl_PartyPet.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fParty Pet|r
 ## Title-itIT: Z-Perl |cffeda55fFamigli Gruppo|r

--- a/ZPerl_Player/ZPerl_Player.lua
+++ b/ZPerl_Player/ZPerl_Player.lua
@@ -23,7 +23,7 @@ local function d(...)
 end
 --@end-debug@]===]
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local format = format
 

--- a/ZPerl_Player/ZPerl_Player.toc
+++ b/ZPerl_Player/ZPerl_Player.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fPlayer|r
 ## Title-itIT: Z-Perl |cffeda55fGiocatore|r

--- a/ZPerl_PlayerBuffs/ZPerl_PlayerBuffs.lua
+++ b/ZPerl_PlayerBuffs/ZPerl_PlayerBuffs.lua
@@ -17,7 +17,7 @@ local function d(fmt, ...)
 end
 --@end-debug@]===]
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 -- setCommon
 local function setCommon(self, filter, buffTemplate)

--- a/ZPerl_PlayerBuffs/ZPerl_PlayerBuffs.toc
+++ b/ZPerl_PlayerBuffs/ZPerl_PlayerBuffs.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fPlayer Buffs|r
 ## Title-itIT: Z-Perl |cffeda55fBenefici Giocatore|r

--- a/ZPerl_PlayerPet/ZPerl_PlayerPet.lua
+++ b/ZPerl_PlayerPet/ZPerl_PlayerPet.lua
@@ -12,7 +12,7 @@ XPerl_RequestConfig(function(new)
 	end
 end, "$Revision: @file-revision@ $")
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local XPerl_Player_Pet_HighlightCallback
 

--- a/ZPerl_PlayerPet/ZPerl_PlayerPet.toc
+++ b/ZPerl_PlayerPet/ZPerl_PlayerPet.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fPlayer Pet|r
 ## Title-itIT: Z-Perl |cffeda55fFamiglio Giocatore|r

--- a/ZPerl_RaidAdmin/ZPerl_RaidAdmin.toc
+++ b/ZPerl_RaidAdmin/ZPerl_RaidAdmin.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fRaid Admin|r
 ## Title-itIT: Z-Perl |cffeda55fAmministrazione Incursione|r

--- a/ZPerl_RaidFrames/ZPerl_Raid.lua
+++ b/ZPerl_RaidFrames/ZPerl_Raid.lua
@@ -36,7 +36,7 @@ end
 
 --local new, del, copy = XPerl_GetReusableTable, XPerl_FreeTable, XPerl_CopyTable
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local format = format
 local strsub = strsub

--- a/ZPerl_RaidFrames/ZPerl_RaidFrames.toc
+++ b/ZPerl_RaidFrames/ZPerl_RaidFrames.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fRaid Frames|r
 ## Title-itIT: Z-Perl |cffeda55fIncursione|r

--- a/ZPerl_RaidHelper/ZPerl_RaidHelper.lua
+++ b/ZPerl_RaidHelper/ZPerl_RaidHelper.lua
@@ -16,7 +16,7 @@ local XTitle
 local pendingTankListChange -- If in combat when tank list changes, then we'll defer it till next time we're out of combat
 local conf
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local GetNumGroupMembers = GetNumGroupMembers
 

--- a/ZPerl_RaidHelper/ZPerl_RaidHelper.toc
+++ b/ZPerl_RaidHelper/ZPerl_RaidHelper.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fRaid Helper|r
 ## Title-itIT: Z-Perl |cffeda55fAiutante Incursione|r

--- a/ZPerl_RaidMonitor/ZPerl_RaidMonitor.lua
+++ b/ZPerl_RaidMonitor/ZPerl_RaidMonitor.lua
@@ -15,7 +15,7 @@ if LCC then
     UnitChannelInfo = function(unit) return LCC:UnitChannelInfo(unit); end
 end
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local GetNumGroupMembers = GetNumGroupMembers
 local GetNumSubgroupMembers = GetNumSubgroupMembers

--- a/ZPerl_RaidMonitor/ZPerl_RaidMonitor.toc
+++ b/ZPerl_RaidMonitor/ZPerl_RaidMonitor.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fRaid Monitor|r
 ## Title-itIT: Z-Perl |cffeda55fMonitor Incursione|r

--- a/ZPerl_RaidPets/ZPerl_RaidPets.lua
+++ b/ZPerl_RaidPets/ZPerl_RaidPets.lua
@@ -13,7 +13,7 @@ end, "$Revision: @file-revision@ $")
 
 --local new, del, copy = XPerl_GetReusableTable, XPerl_FreeTable, XPerl_CopyTable
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local GetNumGroupMembers = GetNumGroupMembers
 

--- a/ZPerl_RaidPets/ZPerl_RaidPets.toc
+++ b/ZPerl_RaidPets/ZPerl_RaidPets.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fRaid Pets|r
 ## Title-itIT: Z-Perl |cffeda55fFamigli Incursione|r

--- a/ZPerl_Target/ZPerl_Target.lua
+++ b/ZPerl_Target/ZPerl_Target.lua
@@ -25,15 +25,15 @@ XPerl_RequestConfig(function(new)
 	end
 end, "$Revision: @file-revision@ $")
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
-local LCD = IsClassic and LibStub and LibStub("LibClassicDurations")
-if IsClassic then
-	LCD.RegisterCallback("ZPerl", "UNIT_BUFF", function(event, unit)
-		if unit == "target" then
-			XPerl_Target_Events:UNIT_AURA(event, unit)
-		end
-	end)
-end
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
+--local LCD = IsClassic and LibStub and LibStub("LibClassicDurations")
+--if IsClassic then
+--	LCD.RegisterCallback("ZPerl", "UNIT_BUFF", function(event, unit)
+--		if unit == "target" then
+--			XPerl_Target_Events:UNIT_AURA(event, unit)
+--		end
+--	end)
+--end
 
 -- Upvalues
 local _G = _G

--- a/ZPerl_Target/ZPerl_Target.toc
+++ b/ZPerl_Target/ZPerl_Target.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fTarget|r
 ## Title-itIT: Z-Perl |cffeda55fBersaglio|r

--- a/ZPerl_TargetTarget/ZPerl_TargetTarget.lua
+++ b/ZPerl_TargetTarget/ZPerl_TargetTarget.lua
@@ -2,7 +2,7 @@
 -- Author: Resike
 -- License: GNU GPL v3, 18 October 2014
 
-local IsClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local IsClassic = WOW_PROJECT_ID >= WOW_PROJECT_CLASSIC
 
 local max = max
 local pairs = pairs

--- a/ZPerl_TargetTarget/ZPerl_TargetTarget.toc
+++ b/ZPerl_TargetTarget/ZPerl_TargetTarget.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 20501
 ## Author: Resike
 ## Title: Z-Perl |cffeda55fTarget's Target|r
 ## Title-itIT: Z-Perl |cffeda55fBersaglio del Bersaglio|r


### PR DESCRIPTION
Set the TOC for Burning Crusade Classic.  Fix the version checking code within the addon to work for BC as well as vanilla classic.  Remove link to the lib classic durations embedded library, as it wasn't working in BC.