### PR TITLE
XPerl_SetExpectedAbsorbs sometimes calling SetValue(infinite)

### DIFF
--- a/ZPerl/ZPerl.lua
+++ b/ZPerl/ZPerl.lua
@@ -4009,7 +4009,7 @@ function XPerl_SetExpectedAbsorbs(self)
 			local min, max = healthBar:GetMinMaxValues()
 			local position = ((max - healthBar:GetValue()) / max) * healthBar:GetWidth()
 
-			if healthBar:GetWidth() <= 0 then
+			if healthBar:GetWidth() <= 0 or healthBar:GetWidth() == position then
 				return
 			end
 


### PR DESCRIPTION
This should fix https://www.curseforge.com/wow/addons/zperl/issues/429

I'm guessing there's a rounding error when performing `(max - healthBar:GetValue()) / max` resulting in it equalling 1.   I'm not sure why else `UnitIsDeadOrGhost(unit)` would return false when `healthBar:GetValue()` returns 0.