### PR TITLE
Update for 10.2.5 result format of GetUnitPowerBarInfo

### DIFF
--- a/ZPerl/ZPerl.lua
+++ b/ZPerl/ZPerl.lua
@@ -1654,11 +1654,11 @@ function XPerl_MinimapButton_Details(tt, ldb)
 end
 
 function XPerl_GetDisplayedPowerType(unitID) -- copied from CompactUnitFrame.lua
-	local _, _, _, _, _, _, showOnRaid, _, _, _, _, _, _, _, _ = not IsClassic and GetUnitPowerBarInfo(unitID)
-	if ( showOnRaid and UnitHasVehicleUI(unitID) and (UnitInParty(unitID) or UnitInRaid(unitID)) ) then
+	local barInfo = not IsClassic and GetUnitPowerBarInfo(unitID)
+	if ( barInfo and barInfo.showOnRaid and UnitHasVehicleUI(unitID) and (UnitInParty(unitID) or UnitInRaid(unitID)) ) then
 		return ALTERNATE_POWER_INDEX
 	else
-		return UnitPowerType(unitID)
+		return (UnitPowerType(unitID)) or 0
 	end
 end
 


### PR DESCRIPTION
In theory this may fix issue #110 / #111

GetUnitPowerBarInfo returns a table, not multiple results.