### PR TITLE
Fix LUA errors for TBC Anniversary client compatibility

### DIFF
--- a/ZPerl_ArcaneBar/ZPerl_ArcaneBar.lua
+++ b/ZPerl_ArcaneBar/ZPerl_ArcaneBar.lua
@@ -93,17 +93,21 @@ end
 local function overrideToggle(value)
 	local pconf = ArcaneBars.player
 	if (pconf) then
+		local frameToUse = PlayerCastingBarFrame or CastingBarFrame -- Sprobuj znalezc PlayerCastingBarFrame, jesli nie, to CastingBarFrame
+
 		if (value) then
 			if (pconf.bar.Overrided) then
-				local CastbarEventHandler = function(event, ...)
-					return XPerl_ArcaneBar_OnEvent(CastingBarFrame, event, ...)
-				end
-				for i, event in pairs(events) do
-					if IsRetail then
-						PlayerCastingBarFrame:RegisterEvent(event)
-					else
-						if event ~= "UNIT_SPELLCAST_INTERRUPTIBLE" and event ~= "UNIT_SPELLCAST_NOT_INTERRUPTIBLE" then
-							CastingBarFrame:RegisterEvent(event)
+				if frameToUse then -- Sprawdzamy czy ramka istnieje
+					local CastbarEventHandler = function(event, ...)
+						return XPerl_ArcaneBar_OnEvent(frameToUse, event, ...)
+					end
+					for i, event in pairs(events) do
+						if IsRetail then
+							frameToUse:RegisterEvent(event)
+						else
+							if event ~= "UNIT_SPELLCAST_INTERRUPTIBLE" and event ~= "UNIT_SPELLCAST_NOT_INTERRUPTIBLE" then
+								frameToUse:RegisterEvent(event)
+							end
 						end
 					end
 				end
@@ -111,12 +115,9 @@ local function overrideToggle(value)
 			end
 		else
 			if (not pconf.bar.Overrided) then
-				if IsRetail then
-					PlayerCastingBarFrame:Hide()
-					PlayerCastingBarFrame:UnregisterAllEvents()
-				else
-					CastingBarFrame:Hide()
-					CastingBarFrame:UnregisterAllEvents()
+				if frameToUse then -- Sprawdzamy czy ramka istnieje
+					frameToUse:Hide()
+					frameToUse:UnregisterAllEvents()
 				end
 				pconf.bar.Overrided = 1
 			end

--- a/ZPerl_Player/ZPerl_Player.lua
+++ b/ZPerl_Player/ZPerl_Player.lua
@@ -2055,6 +2055,8 @@ end
 
 -- XPerl_Player_SetTotems
 function XPerl_Player_SetTotems()
+    if not TotemFrame then return end
+
 	if (pconf.totems and pconf.totems.enable) then
 		TotemFrame:SetParent(XPerl_Player)
 		TotemFrame:ClearAllPoints()
@@ -2220,7 +2222,8 @@ function XPerl_Player_Set_Bits(self)
 		end
 
 		if not IsVanillaClassic then
-			if (pconf.totems and pconf.totems.enable and not self.totemHooked) then
+			-- ZMIANA: Dodano sprawdzenie "and TotemFrame"
+			if (pconf.totems and pconf.totems.enable and not self.totemHooked and TotemFrame) then
 				local moving
 				hooksecurefunc(TotemFrame, "SetPoint", function(self)
 					if not pconf.totems.enable then
@@ -2255,7 +2258,10 @@ function XPerl_Player_Set_Bits(self)
 				self.totemHooked = true
 				XPerl_Player_SetTotems()
 			else
-				XPerl_Player_SetTotems()
+				-- ZMIANA: Dodano sprawdzenie, czy TotemFrame istnieje przed wywołaniem funkcji ustawiającej
+				if TotemFrame then
+					XPerl_Player_SetTotems()
+				end
 			end
 		end
 	end

--- a/ZPerl_PlayerBuffs/ZPerl_PlayerBuffs.lua
+++ b/ZPerl_PlayerBuffs/ZPerl_PlayerBuffs.lua
@@ -177,13 +177,13 @@ function XPerl_Player_BuffSetup(self)
 	if (pconf.buffs.hideBlizzard) then
 		BuffFrame:UnregisterEvent("UNIT_AURA")
 		BuffFrame:Hide()
-		if not IsRetail then
+		if not IsRetail and TemporaryEnchantFrame then -- ZMIANA: Dodano sprawdzenie if TemporaryEnchantFrame
 			TemporaryEnchantFrame:Hide()
 		end
 	else
 		BuffFrame:Show()
 		BuffFrame:RegisterEvent("UNIT_AURA")
-		if not IsRetail then
+		if not IsRetail and TemporaryEnchantFrame then -- ZMIANA: Dodano sprawdzenie if TemporaryEnchantFrame
 			TemporaryEnchantFrame:Show()
 		end
 	end

--- a/ZPerl_RaidFrames/ZPerl_Raid.lua
+++ b/ZPerl_RaidFrames/ZPerl_Raid.lua
@@ -2638,46 +2638,49 @@ function XPerl_Raid_ChangeAttributes()
 	for i = 1, rconf.sortByClass and CLASS_COUNT or (IsVanillaClassic and 9 or (IsPandaClassic and 11 or 13)) do
 		local groupHeader = raidHeaders[i]
 
-		-- Hide this when we change attributes, so the whole re-calc is only done once, instead of for every attribute change
-		groupHeader:Hide()
+		-- ZMIANA: Sprawdzamy, czy nagłówek istnieje, zanim cokolwiek zrobimy
+		if groupHeader then
+			-- Hide this when we change attributes, so the whole re-calc is only done once, instead of for every attribute change
+			groupHeader:Hide()
 
-		if rconf.sortByRole then
-			groupHeader:SetAttribute("groupBy", "ASSIGNEDROLE")
-			groupHeader:SetAttribute("groupingOrder", "TANK,HEALER,DAMAGER,NONE")
-			groupHeader:SetAttribute("startingIndex", (i - 1) * 5 + 1)
-			groupHeader:SetAttribute("unitsPerColumn", 5)
-			groupHeader:SetAttribute("strictFiltering", nil)
-			groupHeader:SetAttribute("groupFilter", nil)
-			--groupHeader:SetAttribute("useparent-toggleForVehicle", true)
-			--groupHeader:SetAttribute("useparent-allowVehicleTarget", true)
-			--groupHeader:SetAttribute("useparent-unitsuffix", true)
-			--groupHeader:SetAttribute("toggleForVehicle", true)
-			--groupHeader:SetAttribute("allowVehicleTarget", true)
-		else
-			groupHeader:SetAttribute("strictFiltering", not rconf.sortByClass)
-			groupHeader:SetAttribute("groupFilter", GroupFilter(i))
-			groupHeader:SetAttribute("groupBy", nil)
-			groupHeader:SetAttribute("groupingOrder", nil)
-			groupHeader:SetAttribute("startingIndex", 1)
-			groupHeader:SetAttribute("unitsPerColumn", nil)
-			--groupHeader:SetAttribute("useparent-toggleForVehicle", true)
-			--groupHeader:SetAttribute("useparent-allowVehicleTarget", true)
-			--groupHeader:SetAttribute("useparent-unitsuffix", true)
-			--groupHeader:SetAttribute("toggleForVehicle", true)
-			--groupHeader:SetAttribute("allowVehicleTarget", true)
-		end
+			if rconf.sortByRole then
+				groupHeader:SetAttribute("groupBy", "ASSIGNEDROLE")
+				groupHeader:SetAttribute("groupingOrder", "TANK,HEALER,DAMAGER,NONE")
+				groupHeader:SetAttribute("startingIndex", (i - 1) * 5 + 1)
+				groupHeader:SetAttribute("unitsPerColumn", 5)
+				groupHeader:SetAttribute("strictFiltering", nil)
+				groupHeader:SetAttribute("groupFilter", nil)
+				--groupHeader:SetAttribute("useparent-toggleForVehicle", true)
+				--groupHeader:SetAttribute("useparent-allowVehicleTarget", true)
+				--groupHeader:SetAttribute("useparent-unitsuffix", true)
+				--groupHeader:SetAttribute("toggleForVehicle", true)
+				--groupHeader:SetAttribute("allowVehicleTarget", true)
+			else
+				groupHeader:SetAttribute("strictFiltering", not rconf.sortByClass)
+				groupHeader:SetAttribute("groupFilter", GroupFilter(i))
+				groupHeader:SetAttribute("groupBy", nil)
+				groupHeader:SetAttribute("groupingOrder", nil)
+				groupHeader:SetAttribute("startingIndex", 1)
+				groupHeader:SetAttribute("unitsPerColumn", nil)
+				--groupHeader:SetAttribute("useparent-toggleForVehicle", true)
+				--groupHeader:SetAttribute("useparent-allowVehicleTarget", true)
+				--groupHeader:SetAttribute("useparent-unitsuffix", true)
+				--groupHeader:SetAttribute("toggleForVehicle", true)
+				--groupHeader:SetAttribute("allowVehicleTarget", true)
+			end
 
-		-- Fix Secure Header taint in combat
-		local maxColumns = groupHeader:GetAttribute("maxColumns") or 1
-		local unitsPerColumn = groupHeader:GetAttribute("unitsPerColumn") or 5
-		local startingIndex = groupHeader:GetAttribute("startingIndex") or 1
-		local maxUnits = maxColumns * unitsPerColumn
+			-- Fix Secure Header taint in combat
+			local maxColumns = groupHeader:GetAttribute("maxColumns") or 1
+			local unitsPerColumn = groupHeader:GetAttribute("unitsPerColumn") or 5
+			local startingIndex = groupHeader:GetAttribute("startingIndex") or 1
+			local maxUnits = maxColumns * unitsPerColumn
 
-		groupHeader:Show()
-		groupHeader:SetAttribute("startingIndex", - maxUnits + 1)
-		groupHeader:SetAttribute("startingIndex", startingIndex)
+			groupHeader:Show()
+			groupHeader:SetAttribute("startingIndex", - maxUnits + 1)
+			groupHeader:SetAttribute("startingIndex", startingIndex)
 
-		SetMainHeaderAttributes(groupHeader)
+			SetMainHeaderAttributes(groupHeader)
+		end -- Koniec sprawdzenia if groupHeader
 	end
 
 	XPerl_Raid_HideShowRaid()

--- a/ZPerl_RaidFrames/ZPerl_Raid.lua
+++ b/ZPerl_RaidFrames/ZPerl_Raid.lua
@@ -2638,7 +2638,6 @@ function XPerl_Raid_ChangeAttributes()
 	for i = 1, rconf.sortByClass and CLASS_COUNT or (IsVanillaClassic and 9 or (IsPandaClassic and 11 or 13)) do
 		local groupHeader = raidHeaders[i]
 
-		-- ZMIANA: Sprawdzamy, czy nagłówek istnieje, zanim cokolwiek zrobimy
 		if groupHeader then
 			-- Hide this when we change attributes, so the whole re-calc is only done once, instead of for every attribute change
 			groupHeader:Hide()
@@ -2680,7 +2679,7 @@ function XPerl_Raid_ChangeAttributes()
 			groupHeader:SetAttribute("startingIndex", startingIndex)
 
 			SetMainHeaderAttributes(groupHeader)
-		end -- Koniec sprawdzenia if groupHeader
+		end
 	end
 
 	XPerl_Raid_HideShowRaid()


### PR DESCRIPTION
Hi!

I've been using Z-Perl on the WoW Classic Anniversary edition (TBC content running on the modern Retail engine). I encountered several LUA errors because the modern client has removed or changed some frames that existed in the original TBC/Classic API (specifically CastingBarFrame, TemporaryEnchantFrame, and Raid Group Headers behavior).

I managed to fix these issues by adding simple null-checks to the code. Here are the changes that make the addon work perfectly on the Anniversary client:

1. ZPerl_ArcaneBar.lua:
Added checks for CastingBarFrame/PlayerCastingBarFrame availability in the 'overrideToggle' function to prevent nil index errors.

2. ZPerl_PlayerBuffs.lua:
Added 'if TemporaryEnchantFrame then' checks in 'XPerl_Player_BuffSetup', as this frame handles differently in the modern engine.

3. ZPerl_Raid.lua:
Added a nil check for 'groupHeader' inside the loop in 'XPerl_Raid_ChangeAttributes', as the loop was trying to access raid groups that don't exist in the current raid composition structure.

4. ZPerl_Player.lua:
Added 'if TotemFrame then' checks to prevent hooksecurefunc errors, as TotemFrame is not always present/initialized in the same way.

These changes are fully backward compatible (safe checks) and allow the addon to load without LUA errors on the new Anniversary servers.

Thanks for your great work on this addon!